### PR TITLE
Allow noise to be 0

### DIFF
--- a/src/gaussian_process/builder.rs
+++ b/src/gaussian_process/builder.rs
@@ -107,7 +107,7 @@ impl<KernelType: Kernel, PriorType: Prior> GaussianProcessBuilder<KernelType, Pr
    /// It correspond to the standard deviation of the noise in the outputs of the training set.
    pub fn set_noise(self, noise: f64) -> Self
    {
-      assert!(noise > 0., "The noise parameter should be strictly over 0.");
+      assert!(noise >= 0., "The noise parameter should non-negative but we tried to set it to {}", noise);
       GaussianProcessBuilder { noise, ..self }
    }
 

--- a/src/gaussian_process/mod.rs
+++ b/src/gaussian_process/mod.rs
@@ -136,7 +136,7 @@ impl<KernelType: Kernel, PriorType: Prior> GaussianProcess<KernelType, PriorType
                         training_outputs: T::InVector)
                         -> Self
    {
-      assert!(noise > 0., "The noise parameter should be strictly over 0.");
+      assert!(noise >= 0., "The noise parameter should non-negative but we tried to set it to {}", noise);
       let training_inputs = T::into_dmatrix(training_inputs);
       let training_outputs = T::into_dvector(training_outputs);
       assert_eq!(training_inputs.nrows(), training_outputs.nrows());


### PR DESCRIPTION
Bayesian Optimisation in presence of noiseless samples is a thing.
Consider for example deterministic computer simulations. For these, it
makes no sense to ever resample the same location and it gives the model
full confidence in the sample locations. This allows the model to fit to
data that it normally struggles with and either gives up or gives the
whole sample a huge variance making it basically pick at random.

My previous work-around for this strictly-positive assert was to set the
noise to `f64::EPSILON` which did work somewhat but it made variance
near samples `NaN`.

I have verified in my program that setting the noise to 0 keeps the
optimisation working and that variance at samples is now 0 which is
exactly what I wanted.